### PR TITLE
Project structure adjustments and bug fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ cover:
 	go test -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
 	firefox ./coverage.html
+
 clean:
 	rm ./coverage*
-
-	

--- a/bucket.go
+++ b/bucket.go
@@ -3,18 +3,20 @@ package delaywheel
 import (
 	"sync"
 	"sync/atomic"
+
+	"github.com/saweima12/delaywheel/internal/list"
 )
 
 type bucket struct {
 	expiration int64
-	tasks      *genericList[*Task]
+	tasks      *list.GenericList[*Task]
 	mu         sync.Mutex
 }
 
 func newBucket() *bucket {
 	return &bucket{
 		expiration: -1,
-		tasks:      newGeneric[*Task](),
+		tasks:      list.NewGeneric[*Task](),
 	}
 }
 

--- a/context.go
+++ b/context.go
@@ -67,7 +67,9 @@ func (ctx *TaskCtx) ReSchedule(d time.Duration) {
 		return
 	}
 
-	newTask := ctx.t.de.createTask(d)
+	newTask := ctx.t.de.getTaskObj(d)
+	newTask.taskID = ctx.t.taskID
+	newTask.state.Store(ctx.t.state.Load())
 	newTask.executor = ctx.t.executor
 	newTask.interval = ctx.t.interval
 	// Attempt to push the new task into delaywheel

--- a/delayWheel.go
+++ b/delayWheel.go
@@ -55,10 +55,9 @@ func create(tickMs int64, wheelSize int, startMs int64) *DelayWheel {
 			Level:  LOG_WARN,
 		},
 
-		pendingTaskCh: make(chan func(), 1),
-		addTaskCh:     make(chan *Task, 1),
-		recycleTaskCh: make(chan *Task, 1),
-		cancelTaskCh:  make(chan uint64, 1),
+		pendingTaskCh: make(chan func(), 10),
+		addTaskCh:     make(chan *Task, 10),
+		cancelTaskCh:  make(chan uint64, 10),
 		stopCh:        make(chan struct{}, 1),
 	}
 	dw.curTime.Store(startMs)
@@ -88,7 +87,6 @@ type DelayWheel struct {
 
 	pendingTaskCh chan func()
 	addTaskCh     chan *Task
-	recycleTaskCh chan *Task
 	cancelTaskCh  chan uint64
 	stopCh        chan struct{}
 }
@@ -113,6 +111,7 @@ func (de *DelayWheel) Stop(stopFunc StopFunc) error {
 
 	err := stopFunc(stopCtx)
 	if err != nil {
+		de.logger.Error("Error during delayWheel shutdown: %v", err)
 		return err
 	}
 
@@ -190,8 +189,6 @@ func (de *DelayWheel) run() {
 			de.addOrRun(task)
 		case bu := <-de.queue.ExpiredCh():
 			de.handleExipredBucket(bu)
-		case task := <-de.recycleTaskCh:
-			de.recycleTask(task)
 		case taskID := <-de.cancelTaskCh:
 			de.cancelTask(taskID)
 		case <-de.stopCh:
@@ -215,27 +212,25 @@ func (de *DelayWheel) advanceClock(expiration int64) {
 }
 
 func (de *DelayWheel) pushTask(t *Task) error {
-	if de.curState.Load() != uint32(STATE_READY) {
-		curState := de.curState.Load()
+	curState := de.curState.Load()
+	if curState != uint32(STATE_READY) {
 		de.logger.Warn("Task submission failed due to the current status being: %v", wheelState(curState))
 		return fmt.Errorf("The delayWheel is not ready and will not accept any tasks.")
 	}
 	de.addTaskCh <- t
+	// Insert into taskmap
+	de.taskMap.Set(t.taskID, t)
 	return nil
 }
 
 func (de *DelayWheel) handleExipredBucket(b *bucket) {
 	// Advance wheel's currentTime.
 	de.advanceClock(b.Expiration())
-
 	for {
 		// Extract all task
 		task, ok := b.tasks.PopFront()
 		if !ok {
 			break
-		}
-		if task.isCancelled.Load() {
-			continue
 		}
 		de.addOrRun(task)
 	}
@@ -246,7 +241,7 @@ func (de *DelayWheel) handleExipredBucket(b *bucket) {
 func (de *DelayWheel) add(task *Task) bool {
 	curTime := de.curTime.Load()
 	// When the expiration time less than one tick. execute directly.
-	if task.expiration < curTime+de.tickMs {
+	if task.expiration <= curTime+de.tickMs {
 		return false
 	}
 
@@ -274,21 +269,24 @@ func (de *DelayWheel) add(task *Task) bool {
 		de.queue.Offer(bucket)
 	}
 
-	// Insert into taskmap
-	de.taskMap.Set(task.taskID, task)
 	return true
 }
 
 func (de *DelayWheel) addOrRun(task *Task) {
-	if task.isCancelled.Load() {
+	if task.IsCanceled() {
+		de.taskMap.Remove(task.taskID)
 		de.recycleTask(task)
 		return
 	}
 
 	if !de.add(task) {
-		// Add into waitGroup.
-		task.wg = &de.wg
+		// Attempt to insert a waitgroup;
+		// if unable, it indicates the task has been canceled, will not executed.
+		if !task.setWaitGroup(&de.wg) {
+			return
+		}
 		de.wg.Add(1)
+		de.taskMap.Remove(task.taskID)
 		// If autoRun is enabled, It will directly start a goroutine for automatic execution.
 		if de.autoRun {
 			go task.Execute()
@@ -299,12 +297,12 @@ func (de *DelayWheel) addOrRun(task *Task) {
 }
 
 func (de *DelayWheel) expandWheel() {
-	// Find last wheel
+	// Find the last wheel
 	target := de.wheel
 	for target.next != nil {
 		target = target.next
 	}
-	// Loading currnet time & create next layer wheel.
+	// Read currnet time & create next layer wheel.
 	curTime := de.curTime.Load()
 	next := newWheel(target.interval, de.wheelSize, curTime)
 	target.next = next
@@ -323,7 +321,7 @@ func (de *DelayWheel) createTask(d time.Duration) *Task {
 func (de *DelayWheel) createContext(t *Task) *TaskCtx {
 	ctx := de.ctxPool.Get(t)
 	ctx.t = t
-	ctx.taskCh = de.addTaskCh
+	ctx.pushFunc = de.pushTask
 	return ctx
 }
 
@@ -334,14 +332,13 @@ func (de *DelayWheel) getAllTask() <-chan shardmap.Tuple[uint64, *Task] {
 func (de *DelayWheel) cancelTask(taskID uint64) {
 	t, ok := de.taskMap.Get(taskID)
 	if !ok {
+		de.logger.Warn("Attempted to cancel a task with ID %d, which does not exist.", taskID)
 		return
 	}
 	t.Cancel()
 }
 
 func (de *DelayWheel) recycleTask(t *Task) {
-	// Remove task from taskMap
-	de.taskMap.Remove(t.taskID)
 	de.taskPool.Put(t)
 }
 

--- a/delayWheel_test.go
+++ b/delayWheel_test.go
@@ -4,45 +4,71 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/saweima12/delaywheel"
 )
 
+func TestCreateUnavaliableWheel(t *testing.T) {
+	_, err := delaywheel.New(time.Microsecond, 20)
+	t.Run("Submission should fail, because tickMs is less than 1 ms", func(t *testing.T) {
+		if err == nil {
+			t.Fail()
+		}
+	})
+}
+
 func TestDelayWheelWithWorker(t *testing.T) {
 	// Create and startup the delaywheel
 	dw, _ := delaywheel.New(1*time.Second, 20,
 		delaywheel.WithLogLevel(delaywheel.LOG_DEBUG),
 	)
+
+	t.Run("Submission should fail because it has not started yet", func(t *testing.T) {
+		// Insert a new task
+		_, err := dw.AfterFunc(time.Second, func(taskCtx *delaywheel.TaskCtx) {})
+		if err == nil {
+			t.Fail()
+		}
+	})
 	dw.Start()
 
-	// Insert a new task
-	dw.AfterFunc(2*time.Second, func(taskCtx *delaywheel.TaskCtx) {
-		fmt.Println(taskCtx)
-	})
+	t.Run("WaitForDone should ensure that the tasks run properly.", func(t *testing.T) {
+		rtn := int32(0)
+		// Insert a scheduled task to execute every 3 seconds.
+		dw.ScheduleFunc(3*time.Second, func(taskCtx *delaywheel.TaskCtx) {
+			atomic.AddInt32(&rtn, 1)
+			fmt.Println("EventTrigger")
+		})
 
-	// Insert a scheduled task to execute every 3 seconds.
-	dw.ScheduleFunc(3*time.Second, func(taskCtx *delaywheel.TaskCtx) {
-		fmt.Println(taskCtx)
-	})
+		// Launch a separate goroutine for executing tasks, which can be replaced with a goroutine pool.
+		done := make(chan struct{}, 1)
+		go func() {
+			for task := range dw.PendingChan() {
+				task()
+			}
+			done <- struct{}{}
+		}()
 
-	// Launch a separate goroutine for executing tasks, which can be replaced with a goroutine pool.
-	go func() {
-		for task := range dw.PendingChan() {
-			task()
+		// Shutdown the delaywheel
+		dw.Stop(func(ctx *delaywheel.StopCtx) error {
+			ctx.WaitForDone(context.Background())
+			return nil
+		})
+
+		<-done
+
+		if atomic.LoadInt32(&rtn) != 1 {
+			t.Errorf("Because it stops shortly after starting, ScheduleFunc should only trigger once. got: %v", rtn)
+			t.Fail()
 		}
-	}()
-
-	// Shutdown the delaywheel
-	dw.Stop(func(ctx *delaywheel.StopCtx) error {
-		ctx.WaitForDone(context.Background())
-		return nil
 	})
 }
 
 func TestBasicFunctionality(t *testing.T) {
-	dw, err := delaywheel.New(1*time.Millisecond, 20,
+	dw, err := delaywheel.New(time.Millisecond, 20,
 		delaywheel.WithAutoRun(),
 	)
 	if err != nil {
@@ -54,9 +80,10 @@ func TestBasicFunctionality(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	_, err = dw.AfterFunc(10*time.Millisecond, func(ctx *delaywheel.TaskCtx) {
+	_, err = dw.AfterFunc(2*time.Millisecond, func(ctx *delaywheel.TaskCtx) {
 		wg.Done()
 	})
+
 	if err != nil {
 		t.Fatalf("Failed to add task: %v", err)
 	}
@@ -66,20 +93,30 @@ func TestBasicFunctionality(t *testing.T) {
 	dw.Stop(nil)
 }
 
-func TestConcurrentSafety(t *testing.T) {
+func TestLargeTasks(t *testing.T) {
 	dw, err := delaywheel.New(1*time.Millisecond, 20,
-		delaywheel.WithAutoRun(),
+		delaywheel.WithCurTaskID(10),
+		delaywheel.WithPendingBufferSize(10),
 	)
 	if err != nil {
 		t.Fatalf("Failed to create DelayWheel: %v", err)
 	}
 	dw.Start()
 
+	go func() {
+		for f := range dw.PendingChan() {
+			f()
+		}
+	}()
+
+	rtn := int32(0)
+	// Simulate concurrent tasks.
 	var wg sync.WaitGroup
-	taskCount := 100
+	taskCount := 100000
 	wg.Add(taskCount)
 	for i := 0; i < taskCount; i++ {
-		_, err := dw.AfterFunc(time.Duration(i+1)*time.Millisecond, func(ctx *delaywheel.TaskCtx) {
+		_, err := dw.AfterFunc(time.Duration(10)*time.Millisecond, func(ctx *delaywheel.TaskCtx) {
+			atomic.AddInt32(&rtn, 1)
 			wg.Done()
 		})
 		if err != nil {
@@ -87,40 +124,68 @@ func TestConcurrentSafety(t *testing.T) {
 		}
 	}
 
-	wg.Wait()
+	dw.Stop(func(stopCtx *delaywheel.StopCtx) error {
+		stopCtx.WaitForDone(context.Background())
+		return nil
+	})
 
-	dw.Stop(nil)
+	fmt.Println("Count", rtn)
+	if rtn != int32(taskCount) {
+		t.Errorf("The result must be %d, got %d", taskCount, rtn)
+		t.Fail()
+	}
+
+	wg.Wait()
 }
 
 // TestGracefulShutdownWithoutTimeout tests stopping the DelayWheel gracefully and waits for all tasks to complete.
 func TestGracefulShutdownWithoutTimeout(t *testing.T) {
-	dw, err := delaywheel.New(1*time.Millisecond, 20, delaywheel.WithAutoRun())
+	dw, err := delaywheel.New(1*time.Millisecond, 20,
+		delaywheel.WithAutoRun(),
+		delaywheel.WithLogLevel(delaywheel.LOG_DEBUG),
+	)
 	if err != nil {
 		t.Fatalf("Failed to create DelayWheel: %v", err)
 	}
 
 	dw.Start()
 
+	answer := 10
+	result := uint32(0)
 	// Add some tasks that will print a message
 	for i := 0; i < 10; i++ {
-		n := i
-		_, err := dw.AfterFunc(time.Duration(i)*time.Second, func(ctx *delaywheel.TaskCtx) {
+		_, err := dw.AfterFunc(time.Duration(i)*time.Millisecond, func(ctx *delaywheel.TaskCtx) {
 			// Task logic here
-			fmt.Println("WithOutTimeout", n)
+			atomic.AddUint32(&result, 1)
 		})
+
 		if err != nil {
 			t.Fatalf("Failed to add task: %v", err)
 		}
-		fmt.Println("Register WithOutTimeout", n)
 	}
 
-	fmt.Println("Start to stop WithOutTimeout")
+	// Testing cancelTask
+	var fail atomic.Bool
+	taskId, err := dw.AfterFunc(2*time.Second, func(ctx *delaywheel.TaskCtx) {
+		fail.Swap(false)
+	})
+	dw.CancelTask(taskId)
+
 	// Stop the DelayWheel and wait for all tasks to complete
 	dw.Stop(func(ctx *delaywheel.StopCtx) error {
 		ctx.WaitForDone(context.Background()) // Pass a fresh context to avoid mixing with the outer one
 		return nil
 	})
-	fmt.Println("Finsihed")
+
+	if fail.Load() {
+		t.Errorf("The fail trigger task, must be canceled.")
+		t.Fail()
+	}
+
+	if result != uint32(answer) {
+		t.Errorf("The rtn must be %d, got %d", answer, result)
+		t.Fail()
+	}
 }
 
 // TestGracefulShutdownWithTimeout tests the behavior of stopping the DelayWheel gracefully under a timeout condition.
@@ -129,17 +194,14 @@ func TestGracefulShutdownWithTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create DelayWheel: %v", err)
 	}
-
 	dw.Start()
 
 	// Add some tasks
 	for i := 0; i < 10; i++ {
 		n := i
-		taskId, err := dw.AfterFunc(time.Duration(n)*100*time.Millisecond, func(ctx *delaywheel.TaskCtx) {
+		_, err := dw.AfterFunc(time.Duration(n)*100*time.Millisecond, func(ctx *delaywheel.TaskCtx) {
 			// Longer task to simulate timeout
-			fmt.Println("WithTimeout:", n)
 		})
-		fmt.Println("Register WithTimout", n, taskId)
 
 		if err != nil {
 			t.Fatalf("Failed to add task: %v", err)
@@ -153,7 +215,6 @@ func TestGracefulShutdownWithTimeout(t *testing.T) {
 	// Stop the DelayWheel with the context that has a timeout
 	err = dw.Stop(func(ctx *delaywheel.StopCtx) error {
 		// Wait for tasks to complete or for the context to be canceled due to timeout
-		fmt.Println("Start to stop WithTimeout")
 		ctx.WaitForDone(cctx)
 		if cctx.Err() != nil {
 			return cctx.Err()
@@ -164,4 +225,96 @@ func TestGracefulShutdownWithTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected Stop to fail due to timeout, but it did not")
 	}
+}
+
+type TestLogger struct{}
+
+func (te *TestLogger) Debug(format string, args ...any) {
+	ptn := format + "\n"
+	fmt.Printf(ptn, args...)
+}
+
+func (te *TestLogger) Info(format string, args ...any) {
+	ptn := format + "\n"
+	fmt.Printf(ptn, args...)
+}
+
+func (te *TestLogger) Error(format string, args ...any) {
+	ptn := format + "\n"
+	fmt.Printf(ptn, args...)
+}
+
+func (te *TestLogger) Warn(format string, args ...any) {
+	ptn := format + "\n"
+	fmt.Printf(ptn, args...)
+}
+
+type TestExecutor struct {
+	Count int32
+}
+
+func (te *TestExecutor) Execute(taskCtx *delaywheel.TaskCtx) {
+	fmt.Println(taskCtx.TaskID(), taskCtx.Expiration(), taskCtx.ExpireTime())
+	atomic.AddInt32(&te.Count, 1)
+
+	if te.Count > 10 {
+		taskCtx.Cancel()
+	}
+}
+
+func TestGrcefulShutdownWithCancelTask(t *testing.T) {
+	dw, err := delaywheel.New(time.Millisecond, 20,
+		delaywheel.WithAutoRun(),
+		delaywheel.WithLogger(&TestLogger{}),
+	)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	t.Run("The tasks will be failed, because the delaywheel not running", func(t *testing.T) {
+		_, err := dw.AfterFunc(time.Second, func(task *delaywheel.TaskCtx) {
+			// This task will be failed.
+		})
+
+		if err == nil {
+			t.Fail()
+		}
+
+		_, err = dw.ScheduleFunc(time.Second, func(task *delaywheel.TaskCtx) {
+			// This task will be failed.
+		})
+
+		if err == nil {
+			t.Fail()
+		}
+	})
+
+	dw.Start()
+
+	t.Run("The executor count should be 1", func(t *testing.T) {
+		executor := TestExecutor{}
+		_, err := dw.AfterExecute(time.Second, &executor)
+		if err != nil {
+			t.Fail()
+		}
+		<-time.After(4 * time.Second)
+		if executor.Count != 1 {
+			t.Fail()
+		}
+	})
+
+	t.Run("The executor count should be 3", func(t *testing.T) {
+		executor := TestExecutor{}
+		taskId, err := dw.ScheduleExecute(time.Second, &executor)
+		if err != nil {
+			t.Fail()
+		}
+		<-time.After(3 * time.Second)
+		dw.CancelTask(taskId)
+		<-time.After(time.Second)
+		if executor.Count != 3 {
+			t.Fail()
+		}
+	})
+
 }

--- a/internal/list/genericList.go
+++ b/internal/list/genericList.go
@@ -1,26 +1,26 @@
-package delaywheel
+package list
 
 import clist "container/list"
 
-type genericList[T comparable] struct {
+type GenericList[T comparable] struct {
 	list *clist.List
 }
 
-func newGeneric[T comparable]() *genericList[T] {
-	return &genericList[T]{
+func NewGeneric[T comparable]() *GenericList[T] {
+	return &GenericList[T]{
 		list: clist.New(),
 	}
 }
 
-func (gl *genericList[T]) PushFront(value T) *clist.Element {
+func (gl *GenericList[T]) PushFront(value T) *clist.Element {
 	return gl.list.PushFront(value)
 }
 
-func (gl *genericList[T]) PushBack(value T) *clist.Element {
+func (gl *GenericList[T]) PushBack(value T) *clist.Element {
 	return gl.list.PushBack(value)
 }
 
-func (gl *genericList[T]) PopAll() []T {
+func (gl *GenericList[T]) PopAll() []T {
 
 	result := make([]T, 0, gl.list.Len())
 
@@ -39,7 +39,7 @@ func (gl *genericList[T]) PopAll() []T {
 	return result
 }
 
-func (gl *genericList[T]) PopFront() (T, bool) {
+func (gl *GenericList[T]) PopFront() (T, bool) {
 	var zero T
 	node := gl.remove(gl.list.Front())
 	if node == nil {
@@ -53,7 +53,7 @@ func (gl *genericList[T]) PopFront() (T, bool) {
 	return result, true
 }
 
-func (gl *genericList[T]) PopBack() (T, bool) {
+func (gl *GenericList[T]) PopBack() (T, bool) {
 	var zero T
 	node := gl.remove(gl.list.Back())
 	if node == nil {
@@ -67,7 +67,7 @@ func (gl *genericList[T]) PopBack() (T, bool) {
 	return result, true
 }
 
-func (gl *genericList[T]) RemoveFirst(t T) {
+func (gl *GenericList[T]) RemoveFirst(t T) {
 	node := gl.list.Front()
 	for {
 		if node == nil {
@@ -86,7 +86,7 @@ func (gl *genericList[T]) RemoveFirst(t T) {
 	}
 }
 
-func (gl *genericList[T]) remove(node *clist.Element) *clist.Element {
+func (gl *GenericList[T]) remove(node *clist.Element) *clist.Element {
 	if node == nil {
 		return nil
 	}

--- a/internal/list/genericList_test.go
+++ b/internal/list/genericList_test.go
@@ -1,7 +1,66 @@
 package list
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestGenericList(t *testing.T) {
+	list := NewGeneric[string]()
 
+	list.PushFront("Hi")
+	list.PushBack("John")
+	list.PushBack("Lee")
+
+	t.Run("The PopBack result should be `Lee`", func(t *testing.T) {
+		val, ok := list.PopBack()
+		if !ok || val != "Lee" {
+			t.Fail()
+		}
+	})
+
+	t.Run("The PopFront result should be `Hi`", func(t *testing.T) {
+		val, ok := list.PopFront()
+		if !ok || val != "Hi" {
+			t.Fail()
+		}
+	})
+
+	list.PushBack("Lee")
+	list.PushBack("Say")
+	list.PushBack("Hello")
+
+	list.RemoveFirst("Say")
+
+	rtn := list.PopAll()
+	answer := []string{"John", "Lee", "Hello"}
+	if ok := compareArr(rtn, answer); !ok {
+		t.Errorf("The result should be %v, got %v", answer, rtn)
+	}
+
+	t.Run("Should get zero value", func(t *testing.T) {
+		val, ok := list.PopFront()
+		if ok || val != "" {
+			t.Fail()
+		}
+
+		val, ok = list.PopBack()
+		if ok || val != "" {
+			t.Fail()
+		}
+	})
+
+}
+
+func compareArr[T comparable](arr1, arr2 []T) bool {
+	if len(arr1) != len(arr2) {
+		return false
+	}
+
+	for i := range arr1 {
+		if arr1[i] != arr2[i] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/list/genericList_test.go
+++ b/internal/list/genericList_test.go
@@ -1,0 +1,7 @@
+package list
+
+import "testing"
+
+func TestGenericList(t *testing.T) {
+
+}

--- a/internal/pqueue/delayQueue.go
+++ b/internal/pqueue/delayQueue.go
@@ -118,11 +118,10 @@ func (dq *delayQueue[T]) refreshTimer(expireTime int64) (isRefresh bool) {
 		default:
 		}
 	}
-	delta := (expireTime - dq.nowFunc()) * int64(time.Millisecond)
-
+	delta := expireTime - dq.nowFunc()
 	if delta <= 0 {
 		return false
 	}
-	dq.t.Reset(time.Duration(delta))
+	dq.t.Reset(time.Duration(delta) * time.Millisecond)
 	return true
 }

--- a/internal/pqueue/priorityQueue_test.go
+++ b/internal/pqueue/priorityQueue_test.go
@@ -31,14 +31,26 @@ func TestProirityQueue(t *testing.T) {
 	popNum := q.Pop().Num
 	if popNum != -50 {
 		t.Errorf("The pop number must be -50, val: %d", popNum)
+		t.Fail()
 	}
 
 	if q.Peek().Num != -20 {
 		t.Errorf("The peek number must be -20, val: %d", q.Peek().Num)
+		t.Fail()
 	}
 
+	answer := []int{-20, -10, 10, 20, 30, 40}
+	rtn := []int{}
 	l := q.Len()
 	for i := 0; i < l; i++ {
-		fmt.Println(q.Pop(), q.Len())
+		item := q.Pop()
+		rtn = append(rtn, item.Num)
 	}
+
+	ok := compareArr(rtn, answer)
+	if !ok {
+		t.Errorf("The result should be %v, got %v", answer, rtn)
+		t.Fail()
+	}
+
 }

--- a/internal/shardmap/option.go
+++ b/internal/shardmap/option.go
@@ -2,12 +2,14 @@ package shardmap
 
 type Option[K comparable, V any] func(*Map[K, V])
 
+// Set the custom sharding function.
 func WithCustomShardingFunc[K comparable, V any](f ShardingFunc[K]) Option[K, V] {
 	return func(m *Map[K, V]) {
 		m.shardingFunc = f
 	}
 }
 
+// Set the sharding number.
 func WithShardNum[K comparable, V any](num uint32) Option[K, V] {
 	return func(m *Map[K, V]) {
 		m.shardNum = num

--- a/internal/shardmap/shardMap_test.go
+++ b/internal/shardmap/shardMap_test.go
@@ -20,7 +20,9 @@ type TestValueItem struct {
 }
 
 func TestSetAndGet(t *testing.T) {
-	nm := shardmap.New[*TestValueItem]()
+	nm := shardmap.New(
+		shardmap.WithShardNum[string, *TestValueItem](64),
+	)
 	nm.Set("Item1", &TestValueItem{Value: "Hello"})
 	nm.Set("Item2", &TestValueItem{Value: "Hello2"})
 
@@ -47,31 +49,68 @@ func TestStringer(t *testing.T) {
 }
 
 func TestNum(t *testing.T) {
-	nm := shardmap.NewNum[uint32, int]()
-	nm.Set(8, 10)
+	nm32 := shardmap.NewNum[uint32, int]()
+	nm16 := shardmap.NewNum[uint16, int]()
+	nm8 := shardmap.NewNum[uint8, int]()
+	nm64 := shardmap.NewNum[uint64, int]()
+	nm32.Set(8, 10)
 
-	val, ok := nm.Get(8)
-	if val != 10 || !ok {
-		t.Errorf("The val must be 10.")
-		return
+	nm8.Set(1, 20)
+	nm16.Set(1, 20)
+	nm32.Set(1, 20)
+	nm64.Set(1, 20)
+
+	val, ok := nm32.Get(1)
+	if val != 20 || !ok {
+		t.Fatalf("The val must be 10.")
+		t.Fail()
 	}
+	nm32.Remove(1)
+	val, ok = nm32.Get(1)
+	if val != 0 || ok {
+		t.Fatalf("The val must be 0")
+		t.Fail()
+	}
+
 }
 
 func TestShardMap(t *testing.T) {
 	nm := shardmap.NewStringer[*TestKeyItem, *TestValueItem]()
 
 	item := &TestKeyItem{Key: "100"}
+	item2 := &TestKeyItem{Key: "200"}
+	item3 := &TestKeyItem{Key: "300"}
 
 	nm.Set(item, &TestValueItem{Value: "Woo"})
-	nm.Set(item, &TestValueItem{Value: "Woo"})
-	nm.Set(item, &TestValueItem{Value: "Woo"})
-	nm.Set(item, &TestValueItem{Value: "Woo"})
-	nm.Set(item, &TestValueItem{Value: "Woo"})
-	nm.Set(item, &TestValueItem{Value: "Wow"})
-	nm.Set(&TestKeyItem{Key: "300"}, &TestValueItem{Value: "Woo"})
+	nm.Set(item2, &TestValueItem{Value: "Woo"})
+	nm.Set(item3, &TestValueItem{Value: "Woo"})
+	nm.Set(&TestKeyItem{Key: "400"}, &TestValueItem{Value: "Woo"})
 
 	val, ok := nm.Get(item)
 
+	for item := range nm.Iter() {
+		fmt.Println(item)
+	}
+
 	fmt.Println(val, ok, nm.Length())
 
+}
+
+const FNV_BASIS = uint32(2166136261)
+
+func TestCustomShardingFunc(t *testing.T) {
+	nm := shardmap.New(shardmap.WithCustomShardingFunc[string, int](func(key string) uint32 {
+		const FNV_PRIME = uint32(16777619)
+		nhash := FNV_BASIS
+		for i := 0; i < len(key); i++ {
+			nhash ^= uint32(key[i])
+			nhash *= FNV_PRIME
+		}
+		return nhash
+	}))
+
+	nm.Set("hi", 10)
+	if val, ok := nm.Get("hi"); val != 10 {
+		fmt.Println(ok)
+	}
 }


### PR DESCRIPTION
### Project structure adjustments
- Move genericList to internal/list package
- Add more logs and comments

### Resolve the issue of potential deadlocks when submitting a large volume of tasks.
- Remove the recycleTaskChannel and switch to direct recycling by the taskPool.
- ReSchedule no longer uses channels but instead employs pushFunc to uniformly add tasks.
- TaskCtx adjusts the wait time logic in WaitForDone to avoid deadlocks caused by infinite accumulation.
- Adjusting the default channel capacity to 10 can provide a better user experience.
